### PR TITLE
feat(translation): implement slang term retrieval endpoints

### DIFF
--- a/backend/src/controllers/translation.controller.ts
+++ b/backend/src/controllers/translation.controller.ts
@@ -108,6 +108,17 @@ const getAllSavedTranslationsByUser = async (c: Context) => {
   return c.json(allSavedTranslations, 200);
 };
 
+const getSlangTermById = async (c: Context) => {
+  const slangTermId = c.req.param("id");
+  const slangTerm = await translationModel.getSlangTermById(slangTermId);
+  return c.json(slangTerm, 200);
+};
+
+const getAllSlangTerms = async (c: Context) => {
+  const slangTerms = await translationModel.getAllSlangTerms();
+  return c.json(slangTerms, 200);
+};
+
 export {
   createTranslation,
   saveTranslation,
@@ -115,4 +126,6 @@ export {
   getTrendingSlang,
   getAllTranslationsByUser,
   getAllSavedTranslationsByUser,
+  getSlangTermById,
+  getAllSlangTerms,
 };

--- a/backend/src/routes/translation.route.ts
+++ b/backend/src/routes/translation.route.ts
@@ -12,6 +12,8 @@ translationRouter.get(
   translationController.getAllSavedTranslationsByUser
 );
 translationRouter.get("/trending", translationController.getTrendingSlang);
+translationRouter.get("/slang/all", translationController.getAllSlangTerms);
+translationRouter.get("/slang/:id", translationController.getSlangTermById);
 translationRouter.post("/ZtoEN", translationController.createTranslation);
 translationRouter.post("/save/:id", translationController.saveTranslation);
 translationRouter.delete(


### PR DESCRIPTION
This commit introduces two new endpoints for retrieving slang terms:

- `/slang/:id`: Retrieves a specific slang term by its ID.
- `/slang/all`: Retrieves all slang terms.

These endpoints are implemented in the translation controller and model, allowing clients to fetch slang term data. The model functions now include select statements to only return the necessary fields.