### PR TITLE
feat(translation.model.ts): return trending slangs with counts

### DIFF
--- a/backend/src/models/translation.model.ts
+++ b/backend/src/models/translation.model.ts
@@ -78,7 +78,7 @@ const getOrCreateSlangTermIds = async (slangTerms: SlangTerm[]) => {
         },
       });
       return term.id;
-    }),
+    })
   );
   return slangTermIds;
 };
@@ -112,7 +112,7 @@ const getAllSlangTerms = async () => {
 
 const createZtoENTranslation = async (
   data: CreateTranslationBody,
-  slangTerms: SlangTerm[],
+  slangTerms: SlangTerm[]
 ) => {
   const slangTermIds = await getOrCreateSlangTermIds(slangTerms);
 
@@ -144,7 +144,7 @@ const createZtoENTranslation = async (
 
 const createENtoZTranslation = async (
   data: CreateTranslationBody,
-  slangTerms: SlangTerm[],
+  slangTerms: SlangTerm[]
 ) => {
   const slangTermIds = await getOrCreateSlangTermIds(slangTerms);
 
@@ -276,35 +276,35 @@ const getTrendingSlang = async () => {
     take: 5,
   });
 
-  // const trendingIds = topMentions.map((entry) => entry.slangTermId);
+  const trendingIds = topMentions.map((entry) => entry.slangTermId);
 
-  // const trendingSlangs = await db.slangTerm.findMany({
-  //   where: {
-  //     id: { in: trendingIds },
-  //   },
-  //   select: {
-  //     id: true,
-  //     term: true,
-  //     meaning: true,
-  //     example: true,
-  //     origin: true,
-  //   },
-  // });
+  const trendingSlangs = await db.slangTerm.findMany({
+    where: {
+      id: { in: trendingIds },
+    },
+    select: {
+      id: true,
+      term: true,
+      meaning: true,
+      example: true,
+      origin: true,
+    },
+  });
 
-  // const slangMap = new Map(trendingSlangs.map((slang) => [slang.id, slang]));
+  const slangMap = new Map(trendingSlangs.map((slang) => [slang.id, slang]));
 
-  // const withCounts = topMentions
-  //   .map((mention) => {
-  //     const slang = slangMap.get(mention.slangTermId);
-  //     return {
-  //       ...slang,
-  //       count: mention._count.slangTermId,
-  //     };
-  //   })
-  //   .filter(Boolean)
-  //   .sort((a, b) => b.count - a.count);
+  const withCounts = topMentions
+    .map((mention) => {
+      const slang = slangMap.get(mention.slangTermId);
+      return {
+        ...slang,
+        count: mention._count.slangTermId,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.count - a.count);
 
-  return topMentions;
+  return withCounts;
 };
 
 export {


### PR DESCRIPTION
feat(translation.model.ts): implement trending slang logic

This commit introduces a new feature to retrieve trending slang terms along with their mention counts. The previous implementation only returned the top mentioned slang term IDs without the actual slang details and counts.

The changes include:
- Fetching slang terms based on the top mentioned IDs.
- Mapping slang terms to a Map for efficient lookup.
- Mapping top mentions to include slang details and counts.
- Filtering out any undefined slang terms.
- Sorting the results by count in descending order.
- Returning the enriched slang terms with counts.