### PR TITLE
feat(frontend): fetch and display trending slang terms on translation…

### DIFF
--- a/backend/src/models/translation.model.ts
+++ b/backend/src/models/translation.model.ts
@@ -273,7 +273,7 @@ const getTrendingSlang = async () => {
         slangTermId: "desc",
       },
     },
-    take: 5,
+    take: 3,
   });
 
   const trendingIds = topMentions.map((entry) => entry.slangTermId);

--- a/frontend/src/contexts/DataContext.jsx
+++ b/frontend/src/contexts/DataContext.jsx
@@ -6,8 +6,10 @@ export const DataContext = createContext()
 export const DataContextProvider = ({ children }) => {
   const { fetchUserData } = useFetch()
   const { fetchSlangs } = useFetch()
+  const { fetchTrendSlangs } = useFetch()
   const [userData, setUserData] = useState(null)
   const [slangTerms, setSlangTerms] = useState([])
+  const [trendSlangs, setTrendSlangs] = useState([])
 
   const reloadUserData = async () => {
     const res = await fetchUserData()
@@ -19,6 +21,11 @@ export const DataContextProvider = ({ children }) => {
     setSlangTerms(data)
   }
 
+  const getTrendSlangs = async () => {
+    const data = await fetchTrendSlangs()
+    setTrendSlangs(data)
+  }
+
   useEffect(() => {
     const handleStorageChange = () => {
       reloadUserData()
@@ -26,12 +33,7 @@ export const DataContextProvider = ({ children }) => {
 
     reloadUserData()
     getSlangTerms()
-
-    // window.addEventListener('storage', handleStorageChange)
-
-    // return () => {
-    //   window.removeEventListener('storage', handleStorageChange)
-    // }
+    getTrendSlangs()
   }, [])
 
   return (
@@ -42,6 +44,8 @@ export const DataContextProvider = ({ children }) => {
         reloadUserData,
         slangTerms,
         setSlangTerms,
+        trendSlangs,
+        setTrendSlangs,
       }}
     >
       {children}

--- a/frontend/src/hooks/useFetch.jsx
+++ b/frontend/src/hooks/useFetch.jsx
@@ -24,5 +24,15 @@ export const useFetch = () => {
     }
   }
 
-  return { fetchSlangs, fetchUserData, fetchError }
+  const fetchTrendSlangs = async () => {
+    try {
+      const res = await api.get(`/translations/trending`)
+      return res.data
+    } catch (e) {
+      console.error(e)
+      setFetchError(e.response.data.message)
+    }
+  }
+
+  return { fetchSlangs, fetchUserData, fetchError, fetchTrendSlangs }
 }

--- a/frontend/src/pages/Translation/TranslationPage.jsx
+++ b/frontend/src/pages/Translation/TranslationPage.jsx
@@ -4,14 +4,17 @@ import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
 import { useState } from 'react'
 import { toast } from 'sonner'
-import { ArrowRightLeft, CopyIcon, Loader2 } from 'lucide-react'
+import { ArrowRightLeft, Copy, Loader2 } from 'lucide-react'
 import api from '@/services/api'
+import SlangCard from '@/components/SlangCard'
+import { useDataContext } from '@/hooks/useDataContext'
 
 const TranslationPage = () => {
   const [inputText, setInputText] = useState('')
   const [outputText, setOutputText] = useState('')
   const [isGenZToEnglish, setIsGenZToEnglish] = useState(true)
   const [isTranslating, setIsTranslating] = useState(false)
+  const { trendSlangs } = useDataContext()
 
   const word = 'Cap'
 
@@ -106,10 +109,13 @@ const TranslationPage = () => {
   return (
     <>
       <DashboardNavBar />
-      <div className="flex items-center justify-around gap-4">
-        <div className="flex flex-col w-full max-w-lg">
+      <div className="flex flex-col lg:flex-row lg:items-center lg:justify-around gap-4 px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col w-full lg:max-w-lg">
           <div className="flex justify-between items-center mb-4">
-            <Label htmlFor="input" className="font-bold text-4xl">
+            <Label
+              htmlFor="input"
+              className="font-bold text-2xl sm:text-3xl lg:text-4xl"
+            >
               {inputLabel}
             </Label>
             <Button
@@ -117,13 +123,13 @@ const TranslationPage = () => {
               size="sm"
               onClick={() => handleCopy(inputText, inputLabel)}
             >
-              <CopyIcon className="h-4 w-4" />
+              <Copy className="h-4 w-4" />
             </Button>
           </div>
           <Textarea
             placeholder={inputPlaceholder}
             id="input"
-            className="focus:ring-purple-200 min-h-[200px] mb-4"
+            className="focus:ring-purple-200 min-h-[150px] sm:min-h-[180px] lg:min-h-[200px] mb-4"
             value={inputText}
             onChange={(e) => setInputText(e.target.value)}
           />
@@ -135,18 +141,23 @@ const TranslationPage = () => {
           </div>
         </div>
 
-        <Button
-          variant="outline"
-          className="hover:bg-white transition-all duration-200 hover:scale-105"
-          onClick={handleDirectionToggle}
-          title={`Switch to ${isGenZToEnglish ? 'English → Gen Z' : 'Gen Z → English'} mode`}
-        >
-          <ArrowRightLeft />
-        </Button>
+        <div className="flex justify-center lg:block">
+          <Button
+            variant="outline"
+            className="hover:bg-white transition-all duration-200 hover:scale-105"
+            onClick={handleDirectionToggle}
+            title={`Switch to ${isGenZToEnglish ? 'English → Gen Z' : 'Gen Z → English'} mode`}
+          >
+            <ArrowRightLeft />
+          </Button>
+        </div>
 
-        <div className="flex flex-col w-full max-w-lg">
+        <div className="flex flex-col w-full lg:max-w-lg">
           <div className="flex justify-between items-center mb-4">
-            <Label htmlFor="input" className="font-bold text-4xl">
+            <Label
+              htmlFor="input"
+              className="font-bold text-2xl sm:text-3xl lg:text-4xl"
+            >
               {outputLabel}
             </Label>
             <Button
@@ -154,20 +165,20 @@ const TranslationPage = () => {
               size="sm"
               onClick={() => handleCopy(outputText, outputLabel)}
             >
-              <CopyIcon className="h-4 w-4" />
+              <Copy className="h-4 w-4" />
             </Button>
           </div>
           <Textarea
             placeholder={outputPlaceholder}
             id="output"
-            className="focus:ring-purple-200 min-h-[200px] mb-4"
+            className="focus:ring-purple-200 min-h-[150px] sm:min-h-[180px] lg:min-h-[200px] mb-4"
             value={outputText}
             onChange={(e) => setOutputText(e.target.value)}
             readOnly
           />
-          <div className="flex justify-between">
-            <Button className="w-20">Copy</Button>
-            <Button className="w-20">Share</Button>
+          <div className="flex gap-2 sm:gap-4 lg:justify-between">
+            <Button className="flex-1 lg:w-20">Copy</Button>
+            <Button className="flex-1 lg:w-20">Share</Button>
           </div>
         </div>
       </div>
@@ -179,10 +190,19 @@ const TranslationPage = () => {
         </span>
       </div>
 
-      <div className="flex flex-col space-y-6 justify-center items-center">
-        <h2 className="text-4xl">Slang Word of the day is</h2>
-        <div className="p-6 rounded-3xl bg-gray-100">
-          <p className="text-6xl font-extrabold">{word}</p>
+      <div className="flex flex-col space-y-8 justify-center items-center py-12 px-4 sm:px-6 lg:px-8">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-center">
+          Slang Words of the day
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 w-full max-w-6xl gap-4 sm:gap-6 lg:gap-8">
+          {trendSlangs.map((slang) => (
+            <SlangCard
+              key={slang.id}
+              term={slang.term}
+              meaning={slang.meaning}
+              example={slang.example}
+            />
+          ))}
         </div>
       </div>
     </>


### PR DESCRIPTION
… page

feat(backend): reduce the number of trending slangs to 3
feat(frontend): add slang card component to display slang terms
feat(frontend): improve responsiveness of translation page layout
feat(frontend): update copy icon to lucide-react's copy icon